### PR TITLE
Change to fix the atime propagation for container based app

### DIFF
--- a/Exercises/Exercise1.md
+++ b/Exercises/Exercise1.md
@@ -60,7 +60,7 @@ You will then use the mxl-info tool to list and inspect the available flow withi
    ```
 1. If you did **NOT** do the preparations steps for either WLS or MacOS, make sure you have a /Volumes/mxl mounted in *tmpfs* or *ram*.
    ```sh
-   mount -t tmpfs -o size=512m tmpfs /Volumes/mxl # on WSL linux
+   sudo mount -t tmpfs -o rw,relatime=0,strictatime,size=512M tmpfs /Volumes/mxl # on WSL linux
    ```
    ```sh
    diskutil erasevolume HFS+ mxl $(hdiutil attach -nomount ram://1048576) # on MacOS

--- a/Exercises/Exercise1.md
+++ b/Exercises/Exercise1.md
@@ -67,7 +67,7 @@ You will then use the mxl-info tool to list and inspect the available flow withi
    ```
 1. Start the containers with the provided .yaml file  
    ```sh
-   docker compose up -d
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
    ```
 1. Look at the containers running  
    ```sh

--- a/Exercises/Exercise2.md
+++ b/Exercises/Exercise2.md
@@ -67,7 +67,7 @@ You will deploy three Docker containers: two MXL writers, each generating a uniq
    ```
 1. Start the containers with the provided .yaml file  
    ```sh
-   docker compose up -d
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
    ```
 1. Look at the containers running  
    ```sh
@@ -112,7 +112,7 @@ You will deploy three Docker containers: two MXL writers, each generating a uniq
    ```
 1. Start up the containers with the updated .yaml file  
    ```sh
-   docker compose up -d
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
    ```
 1. Look at the MXL domain file structure as seen by the reader app. Notice that we only see the flow of the first writer app after we change the domain of writer 2.  
    ```sh

--- a/Exercises/Exercise3.md
+++ b/Exercises/Exercise3.md
@@ -85,7 +85,7 @@ This exercise also showcases the gstreamer clip player plugin (added in [PR #22]
 1. Start the containers
 
    ```sh
-   docker compose up -d
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
    ```
 
 1. On your PC, go to VNC web browser [127.0.0.1:36901](http://127.0.0.1:36901/vnc.html).

--- a/Exercises/Exercise4.md
+++ b/Exercises/Exercise4.md
@@ -66,7 +66,7 @@ This leverage all other concepts learned in previous exercises.
    ```
 1. Start the container with the provided .yaml file  
    ```sh
-   docker compose up -d
+   HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
    ```
 1. Make sure the container is running correctly.  
    ```sh

--- a/Preparation/WSL-Alma.md
+++ b/Preparation/WSL-Alma.md
@@ -89,7 +89,7 @@ In order to run these exercises, you need a Linux base system running with Docke
    ```
 1. Creating a mount point in */etc/fstab* to mount */Volumes/mxl* to *tmpfs*
    ```sh
-   sudo touch /etc/fstab && sudo chmod 666 /etc/fstab && sudo echo 'tmpfs /Volumes/mxl tmpfs defaults,noatime,size=512M 0 0' > /etc/fstab
+   sudo touch /etc/fstab && sudo chmod 666 /etc/fstab && sudo echo 'tmpfs /Volumes/mxl tmpfs rw,relatime=0,strictatime,size=512M 0 0' > /etc/fstab
    ```
 1. Close your linux terminal windows. Using a Windows PowerShell shutdown you linux instance.
    ```sh

--- a/Preparation/WSL-Ubuntu.md
+++ b/Preparation/WSL-Ubuntu.md
@@ -89,7 +89,7 @@ In order to run these exercises, you need a Linux base system running with Docke
    ```
 1. Creating a mount point in */etc/fstab* to mount */Volumes/mxl* to *tmpfs*
    ```sh
-   echo 'tmpfs /Volumes/mxl tmpfs defaults,noatime,size=512M 0 0' | sudo tee -a /etc/fstab
+   echo 'tmpfs /Volumes/mxl tmpfs rw,relatime=0,strictatime,size=512M 0 0' | sudo tee -a /etc/fstab
    ```
 1. Close your linux terminal windows. Using a Windows PowerShell shutdown you linux instance.
    ```sh

--- a/docker/exercise-1/docker-compose.yaml
+++ b/docker/exercise-1/docker-compose.yaml
@@ -1,22 +1,44 @@
 services:
   writer-media-function:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain  
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        # 1. Force Strict Atime
+        mount -o remount,strictatime /Volumes/mxl && 
+        
+        # 2. Setup User
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        
+        # 3. FIX: Create the directory and transfer ownership to the user
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        
+        # 4. Run application as user
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_1 -v /app/v210_flow.json -a /app/audio_flow.json'
+      "
+
   reader-media-function:
     image: ghcr.io/cbcrc/mxl-reader:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-only mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-        read_only: true
-    stdin_open: true
-    tty: true
-volumes:
-  domain:  # Defines the named volume "domain"
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        # Reader just waits for the directory to appear
+        exec su mxluser -c 'while true; do /app/mxl-info -d /Volumes/mxl/domain_1 -l; sleep 1; done'
+      "

--- a/docker/exercise-2/data/docker-compose.yaml
+++ b/docker/exercise-2/data/docker-compose.yaml
@@ -1,32 +1,56 @@
 services:
   writer-media-function:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_1 -v /app/v210_flow.json -t \"Original Flow\"'
+      "
+
   writer-media-function-2:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_2
-        target: /domain
-      - ./data/v210_flow_2.json:/app/v210_flow_2.json  # Example: Upload specific file into container
-    command: ["/app/mxl-gst-testsrc", "-d", "/domain", "-v", "/app/v210_flow_2.json", "-t", "NEW Flow 2"]
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+      - ./data/v210_flow_2.json:/app/v210_flow_2.json
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_2 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_2 &&
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_2 -v /app/v210_flow_2.json -t \"NEW Flow 2\"'
+      "
+
   reader-media-function:
     image: ghcr.io/cbcrc/mxl-reader:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-only mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-        read_only: true
-    stdin_open: true
-    tty: true
-volumes:
-  domain:  # Defines the named volume "domain"
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        exec su mxluser -c 'while true; do /app/mxl-info -d /Volumes/mxl/domain_1 -l; sleep 1; done'
+      "

--- a/docker/exercise-2/docker-compose.yaml
+++ b/docker/exercise-2/docker-compose.yaml
@@ -1,32 +1,56 @@
 services:
   writer-media-function:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_1 -v /app/v210_flow.json -t \"Original Flow\"'
+      "
+
   writer-media-function-2:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-      - ./data/v210_flow_2.json:/app/v210_flow_2.json  # Example: Upload specific file into container
-    command: ["/app/mxl-gst-testsrc", "-d", "/domain", "-v", "/app/v210_flow_2.json", "-t", "NEW Flow 2"]
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+      - ./data/v210_flow_2.json:/app/v210_flow_2.json
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_1 -v /app/v210_flow_2.json -t \"NEW Flow 2\"'
+      "
+
   reader-media-function:
     image: ghcr.io/cbcrc/mxl-reader:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-only mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-        read_only: true
-    stdin_open: true
-    tty: true
-volumes:
-  domain:  # Defines the named volume "domain"
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        exec su mxluser -c 'while true; do /app/mxl-info -d /Volumes/mxl/domain_1 -l; sleep 1; done'
+      "

--- a/docker/exercise-3/docker-compose.yaml
+++ b/docker/exercise-3/docker-compose.yaml
@@ -1,47 +1,70 @@
 services:
   writer-media-function:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-    command: ["/app/mxl-gst-testsrc", "-d", "/domain", "-v", "/app/v210_flow.json", "-t", "Original Flow"]
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_1 -v /app/v210_flow.json -t \"Original Flow\"'
+      "
+
   clip-player-function:
     image: ghcr.io/cbcrc/mxl-clip-player:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
       - ../../build-images/sizzle.ts:/app/sizzle.ts
-    command: ["/app/mxl-gst-looping-filesrc", "-d", "/domain", "-i", "/app/sizzle.ts"]
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        exec su mxluser -c '/app/mxl-gst-looping-filesrc -d /Volumes/mxl/domain_1 -i /app/sizzle.ts'
+      "
+
   reader-media-function:
     image: ghcr.io/cbcrc/mxl-reader:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-        read_only: true
-    stdin_open: true
-    tty: true
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        exec su mxluser -c 'while true; do /app/mxl-info -d /Volumes/mxl/domain_1 -l; sleep 1; done'
+      "
+
   vnc-viewer:
-    image: accetto/ubuntu-vnc-xfce-g3:24.04 # VNC viewer to connect to the writer-media-function
+    image: accetto/ubuntu-vnc-xfce-g3:24.04
     platform: linux/amd64
     restart: unless-stopped
+    privileged: true
+    # Note: We do NOT override entrypoint here as it breaks VNC startup.
+    # We just ensure it sees the same volume path.
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-        read_only: true
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
       - ./data:/root
     ports:
-      - "36901:6901"  # Maps port 6901 of the container to port 36901 on the host
-    working_dir: /root  # Sets the working directory inside the container to /root
-
-volumes:
-  domain:  # Defines the named volume "domain"
+      - "36901:6901"
+    working_dir: /root

--- a/docker/exercise-4/docker-compose.yaml
+++ b/docker/exercise-4/docker-compose.yaml
@@ -1,11 +1,19 @@
 services:
   writer-media-function:
     image: ghcr.io/cbcrc/mxl-writer:latest
-    platform: linux/amd64
-    restart: unless-stopped
+    privileged: true
+    user: "root"
+    environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
     volumes:
-      - type: bind   # Maps the named volume "/mxl" (in memory) to /domain inside the container, in read-write mode.
-        source: /Volumes/mxl/domain_1
-        target: /domain
-volumes:
-  domain:  # Defines the named volume "domain"
+      - /Volumes/mxl:/Volumes/mxl:rw,shared
+    entrypoint: >
+      sh -c "
+        mount -o remount,strictatime /Volumes/mxl && 
+        groupadd -g \${HOST_GID:-1000} mxlgroup || true &&
+        useradd -u \${HOST_UID:-1000} -g \${HOST_GID:-1000} mxluser || true &&
+        mkdir -p /Volumes/mxl/domain_1 &&
+        chown mxluser:mxlgroup /Volumes/mxl/domain_1 &&
+        exec su mxluser -c '/app/mxl-gst-testsrc -d /Volumes/mxl/domain_1 -v /app/v210_flow.json -a /app/audio_flow.json'
+      "


### PR DESCRIPTION
Change to fix the atime propagation for container based reader and writer. We still need a reader attach to a writer for the last read time to update. Our reader container is not a real reader, it is just mxl-info running constantly. I used the portable reader to do this.


Key Changes Applied:
Permissions: All MXL containers now run as root initially (user: "root") with privileged: true.

Environment: HOST_UID and HOST_GID are passed to match your host user.

Volumes: Switched to mounting the host parent /Volumes/mxl to the exact same path inside the container (/Volumes/mxl) with rw,shared.

Entrypoints: Added the script to remount strictatime, create the mxluser, fix directory ownership, and run the application.

Closes #17 