### PR TITLE
Move dmf-mxl submodule to release/v1.1 (84350f7c)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "dmf-mxl"]
 	path = dmf-mxl
 	url = https://github.com/dmf-mxl/mxl.git
-	branch = release/v1.0
+	branch = release/v1.1
 	ignore = untracked


### PR DESCRIPTION
Picks up PR #643 (continuous flow futex notification) plus its follow-up d345d85, and all of PR #588, which adds label, description and group-hint properties to mxlsink.

Also retargets the tracked branch from release/v1.0 to release/v1.1. Note the mxl version string goes 1.2.0-dev -> 1.1.0-rc1: the single commit left behind was main's version bump.